### PR TITLE
[Repo Agent] Code improvements for metalambda

### DIFF
--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,6 +1,9 @@
 use wasm_bindgen::prelude::*;
 use serde::{Serialize, Deserialize};
 
+const FREQ_MIN: f32 = -1000.0;
+const FREQ_MAX: f32 = 1000.0;
+
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize)]
 pub struct LifeForm {
@@ -8,6 +11,14 @@ pub struct LifeForm {
     pub y_freq: f32,
     pub z_freq: f32,
     pub mutation: f32,
+}
+
+fn sanitize_freq(value: f32) -> f32 {
+    if value.is_nan() {
+        0.0
+    } else {
+        value.clamp(FREQ_MIN, FREQ_MAX)
+    }
 }
 
 #[wasm_bindgen]
@@ -19,17 +30,25 @@ impl LifeForm {
 
     #[wasm_bindgen]
     pub fn mutate(&mut self) {
-        self.x_freq += (js_sys::Math::random() as f32 - 0.5) * self.mutation;
-        self.y_freq += (js_sys::Math::random() as f32 - 0.5) * self.mutation;
-        self.z_freq += (js_sys::Math::random() as f32 - 0.5) * self.mutation;
+        let dx = (js_sys::Math::random() as f32 - 0.5) * self.mutation;
+        let dy = (js_sys::Math::random() as f32 - 0.5) * self.mutation;
+        let dz = (js_sys::Math::random() as f32 - 0.5) * self.mutation;
+
+        self.x_freq = sanitize_freq(self.x_freq + dx);
+        self.y_freq = sanitize_freq(self.y_freq + dy);
+        self.z_freq = sanitize_freq(self.z_freq + dz);
     }
 }
 
 #[wasm_bindgen]
-pub fn step_simulation(json_state: &str) -> String {
-    let mut life_forms: Vec<LifeForm> = serde_json::from_str(json_state).unwrap_or_default();
+pub fn step_simulation(json_state: &str) -> Result<String, JsValue> {
+    let mut life_forms: Vec<LifeForm> = serde_json::from_str(json_state)
+        .map_err(|e| JsValue::from_str(&format!("Deserialization error: {}", e)))?;
+
     for lf in &mut life_forms {
         lf.mutate();
     }
-    serde_json::to_string(&life_forms).unwrap()
+
+    serde_json::to_string(&life_forms)
+        .map_err(|e| JsValue::from_str(&format!("Serialization error: {}", e)))
 }


### PR DESCRIPTION
## Automated Improvements by Repo Agent

This PR contains 1 AI-generated code improvement.

### Changes
- **wasm/src/lib.rs**: Two categories of issues were fixed:

1. **Error handling in step_simulation (critical):**
   - Changed the return type from `String` to `Result<String, JsValue>` so errors are propagated to JavaScript instead of being silently swallowed or causing a panic.
   - Replaced `serde_json::from_str(...).unwrap_or_default()` with `.map_err(|e| JsValue::from_str(...))? ` so deserialization errors are surfaced to the JS caller with a descriptive message rather than silently returning an empty Vec.
   - Replaced `serde_json::to_string(...).unwrap()` with `.map_err(|e| JsValue::from_str(...))` so serialization failures are also propagated as a JS error instead of panicking and crashing the WASM module.

2. **Unbounded mutation producing NaN or infinite values (high):**
   - Introduced `FREQ_MIN` and `FREQ_MAX` constants to define the valid frequency range.
   - Added a `sanitize_freq` helper function that first checks for NaN (resetting to `0.0` if found) and then clamps the value within `[FREQ_MIN, FREQ_MAX]`.
   - Updated `mutate()` to compute deltas in local variables and then apply `sanitize_freq` to each resulting frequency before storing it, ensuring that repeated mutations cannot drive values to infinity, negative infinity, or NaN.

> Generated by Repo Agent